### PR TITLE
CB.setBorder to style top row

### DIFF
--- a/man/CellBlock.Rd
+++ b/man/CellBlock.Rd
@@ -153,7 +153,7 @@ CB.setBorder( cellBlock, border, rowIndex, colIndex)
   # set the border on the top row of the Cell Block
   border <-  Border(color="blue", position=c("TOP", "BOTTOM"),
     pen=c("BORDER_THIN", "BORDER_THICK"))
-  CB.setBorder(cb, border, 1:1000, 1)
+  CB.setBorder(cb, border, 1, 1:1000)
 
 
   # Don't forget to save the workbook ...  


### PR DESCRIPTION
Call to `CB.setBorder()` is supposed to style top row TOP/BOTTOM borders. However, it is actually styling the left column instead.
