### PR TITLE
Do not Depend (use Imports)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Read, write, format Excel 2007 and Excel 97/2000/XP/2003 files
 Version: 0.6.0
 Date: 2015-11-29
-Depends: rJava, xlsxjars
+Imports: rJava, xlsxjars
 LazyLoad: yes
 Author: Adrian A. Dragulescu
 Maintainer: Adrian A. Dragulescu <adrian.dragulescu@gmail.com>

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,4 @@
 import(rJava)
 import("xlsxjars")
 exportPattern("^[^\\.]")
+S3method(CellBlock,default)

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,11 @@
 NEWS for package xlsx
 
+Changes in version 0.6.1 (unreleased)
+
+ o Export the S3 method for CellBlock
+
+ o Do not depend (just import) rJava and xlsxjars
+
 Changes in version 0.6.0 (released 2015-11-29)
 
  o Added support to read and write password protected xlsx files.
@@ -10,8 +16,6 @@ Changes in version 0.6.0 (released 2015-11-29)
 
  o Fixed a bug in read.xlsx when an empty rows was triggering an
  error.  Reported by maxnax, see issue 57.
-
- o Export the S3 method for CellBlock
 
  o TODO: implement a chart wrapper 
 

--- a/NEWS
+++ b/NEWS
@@ -11,6 +11,8 @@ Changes in version 0.6.0 (released 2015-11-29)
  o Fixed a bug in read.xlsx when an empty rows was triggering an
  error.  Reported by maxnax, see issue 57.
 
+ o Export the S3 method for CellBlock
+
  o TODO: implement a chart wrapper 
 
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1,5 +1,4 @@
 # .guess_cell_type
-# .onAttach
 # .onLoad
 # .Rcolor2XLcolor
 # .splitBlocks
@@ -37,9 +36,10 @@
 
 ####################################################################
 #
-.onAttach <- function(libname, pkgname)
+.onLoad <- function(libname, pkgname)
 {
-  .jpackage(pkgname)  # needed to load RInterface.java
+  rJava::.jpackage("xlsxjars")
+  rJava::.jpackage(pkgname)  # needed to load RInterface.java
   
   # what's your java  version?  Need > 1.5.0.
   jversion <- .jcall('java.lang.System','S','getProperty','java.version')
@@ -49,14 +49,6 @@
   
   wb <- createWorkbook()   # load/initialize jars here as it takes 
   rm(wb)                   # a few seconds ...
- }
-
-
-####################################################################
-#
-.onLoad <- function(libname, pkgname)
-{
-  .jpackage("xlsxjars")
   
   options(xlsx.date.format = "m/d/yyyy")   # e.g. 3/18/2013
   options(xlsx.datetime.format = "m/d/yyyy h:mm:ss")  # e.g. 3/18/2013 05:25:51


### PR DESCRIPTION
This PR changes how the xlsx package is loaded in order to be able to use it from other packages without needing to Depend on it.

It also fixes the Cellblock.default S3 method, that was not exported in the NAMESPACE.

Packages that depend on xlsx can add `xlsx` to the `Imports:` section of the `DESCRIPTION` file. Then, they can use functions with the `::` notation: `xlsx::createWorkbook` (recommended) or they can write `import(xlsx)` in the `NAMESPACE` file in order to make all the `xlsx` functions available to their package.

Packages that want to optionally depend on xlsx can add `xlsx` to the `Suggests:` section of the `DESCRIPTION` file and then in all functions that use `xlsx` they need to make sure xlsx is imported:

```r
my_exporting_to_xlsx(mystuff) {
  if (!requireNamespace("xslx", quietly=TRUE)) {
    stop("Please install xlsx to use this function")
  }
  xlsx::createWorkbook(...)
  ...
}
```

This PR is important in the xlsx package because it uses rJava, which is prone to installation errors in some platforms, so having a reliable and optional dependency on xlsx is very desirable.
