### PR TITLE
Handling Excel cell size limit

### DIFF
--- a/R/ExcelConstants.R
+++ b/R/ExcelConstants.R
@@ -1,0 +1,3 @@
+# This file defines Excel specific constants
+
+EXCEL_LIMIT_MAX_CHARS_IN_CELL <- 32767

--- a/R/addDataFrame.R
+++ b/R/addDataFrame.R
@@ -97,6 +97,13 @@ addDataFrame <- function(x, sheet, col.names=TRUE, row.names=TRUE,
       haveNA <- is.na(aux)
       if (any(haveNA))
         aux[haveNA] <- characterNA
+
+      # Excel max cell size limit 
+      if (max(nchar(aux)) > EXCEL_LIMIT_MAX_CHARS_IN_CELL) {
+          warning(sprintf("Some cells exceed Excel's limit of %d characters and they will be truncated", 
+                          EXCEL_LIMIT_MAX_CHARS_IN_CELL))
+          aux <- strtrim(aux, EXCEL_LIMIT_MAX_CHARS_IN_CELL)   
+      }
     }
 #browser()
    .jcall( cellBlock$ref, "V", setDataMethod,


### PR DESCRIPTION
Fixes issue #75 

If any cell has more than the Excel limit (32767 characters) then displays a warning and trim to the the max size. 