### PR TITLE
Remove version check

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -43,15 +43,6 @@
 
   set_java_tmp_dir(getOption("xlsx.tempdir", tempdir()))
 
-  # what's your java  version?  Need > 1.5.0.
-  jversion <- .jcall('java.lang.System','S','getProperty','java.version')
-
-  parse_version <- regexpr("[0-9]+\\.[0-9]+\\.[0-9]+", jversion)
-  clean_version <- substr(jversion, parse_version, attr(parse_version, "match.length"))
-  if (utils::compareVersion(clean_version,"1.5.0") < 0)
-    warning(paste("Your java version is ", jversion,
-                 ".  Need 1.5.0 or higher.", sep=""))
-
   wb <- createWorkbook()   # load/initialize jars here as it takes
   rm(wb)                   # a few seconds ...
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -49,7 +49,7 @@
   parse_version <- regexpr("[0-9]+\\.[0-9]+\\.[0-9]+", jversion)
   clean_version <- substr(jversion, parse_version, attr(parse_version, "match.length"))
   if (utils::compareVersion(clean_version,"1.5.0") < 0)
-    stop(paste("Your java version is ", jversion,
+    warning(paste("Your java version is ", jversion,
                  ".  Need 1.5.0 or higher.", sep=""))
 
   wb <- createWorkbook()   # load/initialize jars here as it takes

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -7,6 +7,7 @@ test_java_version <- function(version){
   )
 }
 test_that("version comparison works", {
+  skip("no longer checking version")
   # the previous version comparison failed in some locales
   expect_error(test_java_version("0.99.0"))
   expect_error(test_java_version("1.0.0"))


### PR DESCRIPTION
Close #154 

Remove the version check. At this point, 1.5 is so old, and troublesome Java versions so rampant, that we probably cause more trouble by checking than by not checking.