### PR TITLE
addDataFrame.Rd documentation RE:date/time format

### DIFF
--- a/man/addDataFrame.Rd
+++ b/man/addDataFrame.Rd
@@ -77,8 +77,17 @@ package options \code{xlsx.date.format} and \code{xlsx.datetime.format}.
 They need to be specified in Java date format
 \url{https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html}.
 }
+Changes to the xlsx date/time formats needs to be passed to the R session using the
+function \code{option()} not as an xlsx package parameter. 
+
+An example of this syntax is shown below as a comment.
 \examples{
 
+# to change the default date format use something like this
+  # options(
+  #       xlsx.date.format = 'dd/MM/YYYY',
+  #       xlsx.datetime.format = 'dd/MM/YYYY HH:mm:ss'
+  #)
 
   wb <- createWorkbook()
   sheet  <- createSheet(wb, sheetName="addDataFrame1")
@@ -93,10 +102,6 @@ They need to be specified in Java date format
   cs3 <- CellStyle(wb) + Font(wb, isBold=TRUE) + Border()  # header
   addDataFrame(data, sheet, startRow=3, startColumn=2, colnamesStyle=cs3,
     rownamesStyle=cs1, colStyle=list(`2`=cs2, `3`=cs2))
-
-  # to change the default date format use something like this
-  # options(xlsx.date.format="dd MMM, yyyy")
-
 
   # Don't forget to save the workbook ...
   # saveWorkbook(wb, file)


### PR DESCRIPTION
I struggled to interpret the documentation for the addDataFrame function in relation to date time formats when writing xlsx.

Outside of Rmarkdown I rarely see the options() function used to control the output of functions. So it wasn't immediately clear that this was what I was supposed to use to control date formats within xlsx.

I have made a suggestion as to how this might be more explicitly communicated.